### PR TITLE
#17[bugfix] CharacterSheet name error handling review

### DIFF
--- a/RPGManager_development/src/rpg_database/character_sheet/CharacterSheet.java
+++ b/RPGManager_development/src/rpg_database/character_sheet/CharacterSheet.java
@@ -28,7 +28,11 @@ public class CharacterSheet {
 	protected HashMap<Fields, Object> characterData;
 
 	public CharacterSheet(String entryName) {
-		this.entryName = entryName;
+		if (entryName.matches("^(?U)[\\p{Alpha}_]+")) {
+			this.entryName = entryName;
+		} else {
+			throw new IllegalArgumentException("Only alphabet characters and '_' are allowed!");
+		}
 		this.characterData = new HashMap<>();
 
 		for (Fields field : Fields.values()) {

--- a/RPGManager_development/test/unit_test/character_sheet_unit_tests/CharacterSheetUnitTests.java
+++ b/RPGManager_development/test/unit_test/character_sheet_unit_tests/CharacterSheetUnitTests.java
@@ -30,6 +30,18 @@ public class CharacterSheetUnitTests {
 	// test methods
 	// exception tests
 	@Test
+	public void expectException_SetCharacterEntryNameMalformedInputSpecialCharacters() {
+		expectExceptionWithMessage(IllegalArgumentException.class, "Only alphabet characters and '_' are allowed!");
+		new CharacterSheet("T%bor_k!ri*lpja}");
+	}
+
+	@Test
+	public void expectException_SetCharacterEntryNameMalformedInputSpace() {
+		expectExceptionWithMessage(IllegalArgumentException.class, "Only alphabet characters and '_' are allowed!");
+		new CharacterSheet("Tibor Karilapja");
+	}
+
+	@Test
 	public void expectException_SetCharacterNameMalformedInput() {
 		expectExceptionWithMessage(InvalidParameterException.class, "class java.lang.Double value is not an instance of class java.lang.String");
 		final double malformedInput = 26.12;


### PR DESCRIPTION
@Pluci Itt az első gyors fix a backlogból :) Ezúttal kipróbáltam milyen külön branchre csinálni a megoldást, egyébként nem olyan meredek

- Added character sheet entry name check(throws illegal argument
exception)
- Added exception tests
- Only alphabet characters and the '_' character are allowed for entry
names