### PR TITLE
[bugfix]Fixed unstable testcase, and split APOSTATE

### DIFF
--- a/RPGManager_development/src/rpg_database/character_sheet/Background.java
+++ b/RPGManager_development/src/rpg_database/character_sheet/Background.java
@@ -8,21 +8,21 @@ import rpg_database.character_sheet.interfaces.CustomSetter;
 
 public enum Background implements CustomSetter<Background> {
 	// TODO lot of enum information. Factory class for reading from file?
-	ANDER_SURVIVOR("Ander Survivor", playAs_Mage_Warrior_Rogue()), APOSTATE("Apostate", playAs_Mage()),
-	ANTIVAN_WAYFARER("Antivan Wayfarer", playAs_Warrior_Rogue()), AVVAR("Avvar", playAs_Mage_Warrior_Rogue()),
-	CHASIND_WILDER("Chasind Wilder", playAs_Mage_Warrior_Rogue()), CIRCLE_MAGE("Circle Mage", playAs_Mage()),
-	CITY_ELF("City Elf", playAs_Warrior_Rogue()), DALISH_ELF("Dalish Elf", playAs_Mage_Warrior_Rogue()), DWARF_DUSTER("Dwarf Duster", playAs_Rogue()),
+	ANDER_SURVIVOR("Ander Survivor", playAs_Mage_Warrior_Rogue()), ANTIVAN_WAYFARER("Antivan Wayfarer", playAs_Warrior_Rogue()),
+	AVVAR("Avvar", playAs_Mage_Warrior_Rogue()), CHASIND_WILDER("Chasind Wilder", playAs_Mage_Warrior_Rogue()),
+	CIRCLE_MAGE("Circle Mage", playAs_Mage()), CITY_ELF("City Elf", playAs_Warrior_Rogue()), DALISH_ELF("Dalish Elf", playAs_Mage_Warrior_Rogue()),
+	DWARF_DUSTER("Dwarf Duster", playAs_Rogue()), ELF_APOSTATE("Elf Apostate", playAs_Mage()),
 	ESCAPED_ELVEN_SLAVE("Escaped Elven Slave", playAs_Mage_Warrior_Rogue()), FERELDAN_CRAFTSMEN("Fereldan Craftsmen", playAs_Warrior_Rogue()),
 	FERELDAN_FREEMAN("Fereldan Freeman", playAs_Warrior_Rogue()), FERELDAN_NOBLE("Fereldan Noble", playAs_Warrior_Rogue()),
 	FREE_MARCHER("Free Marcher", playAs_Warrior_Rogue()), HIGH_BORN_DWARF("High Born Dwarf", playAs_Warrior_Rogue()),
-	LOW_BORN_DWARF("Low Born Dwarf", playAs_Warrior_Rogue()), NEVARRAN_ADVENTURER("Nevarran Adventurer", playAs_Warrior_Rogue()),
-	ORLESIAN_COMMONER("Orlesian Commoner", playAs_Warrior_Rogue()), ORLESIAN_EXILE("Orlesian Exile", playAs_Mage_Warrior_Rogue()),
-	ORLESIAN_NOBLE("Orlesian Noble", playAs_Warrior_Rogue()), ORLESIAN_STUDENT("Orlesian Student", playAs_Warrior_Rogue()),
-	QUNARI_BERESAAD("Qunari Beresaad", playAs_Warrior_Rogue()), RIVAINI_MERCHANT("Rivaini Merchant", playAs_Warrior_Rogue()),
-	SEHERON_CONVERT("Seheron Convert", playAs_Warrior_Rogue()), SURFACE_DWARF("Surface Dwarf", playAs_Warrior_Rogue()),
-	TAL_VASHOTH("Tal-Vashoth", playAs_Mage_Warrior_Rogue()), TEVINTER_ALTUS("Tevinter Altus", playAs_Mage()),
-	TEVINTER_LAETAN("Tevinter Laetan", playAs_Mage()), TEVINTER_SOPORATI("Tevinter Soporati", playAs_Warrior_Rogue()),
-	WAKING_SEA_RAIDER("Waking Sea Raider", playAs_Warrior_Rogue());
+	HUMAN_APOSTATE("Human Apostate", playAs_Mage()), LOW_BORN_DWARF("Low Born Dwarf", playAs_Warrior_Rogue()),
+	NEVARRAN_ADVENTURER("Nevarran Adventurer", playAs_Warrior_Rogue()), ORLESIAN_COMMONER("Orlesian Commoner", playAs_Warrior_Rogue()),
+	ORLESIAN_EXILE("Orlesian Exile", playAs_Mage_Warrior_Rogue()), ORLESIAN_NOBLE("Orlesian Noble", playAs_Warrior_Rogue()),
+	ORLESIAN_STUDENT("Orlesian Student", playAs_Warrior_Rogue()), QUNARI_BERESAAD("Qunari Beresaad", playAs_Warrior_Rogue()),
+	RIVAINI_MERCHANT("Rivaini Merchant", playAs_Warrior_Rogue()), SEHERON_CONVERT("Seheron Convert", playAs_Warrior_Rogue()),
+	SURFACE_DWARF("Surface Dwarf", playAs_Warrior_Rogue()), TAL_VASHOTH("Tal-Vashoth", playAs_Mage_Warrior_Rogue()),
+	TEVINTER_ALTUS("Tevinter Altus", playAs_Mage()), TEVINTER_LAETAN("Tevinter Laetan", playAs_Mage()),
+	TEVINTER_SOPORATI("Tevinter Soporati", playAs_Warrior_Rogue()), WAKING_SEA_RAIDER("Waking Sea Raider", playAs_Warrior_Rogue());
 
 	private final String text;
 	private final ArrayList<BaseClasses> baseClasses;

--- a/RPGManager_development/test/unit_test/character_sheet_unit_tests/BackgroundUnitTests.java
+++ b/RPGManager_development/test/unit_test/character_sheet_unit_tests/BackgroundUnitTests.java
@@ -37,7 +37,7 @@ public class BackgroundUnitTests {
 		expectExceptionWithMessage(InvalidCharacterClassException.class, "Apostate is not a Warrior background!");
 		CharacterSheet characterSheet = createCharacterSheetWithCustomClassesAndLevel(BaseClasses.WARRIOR, new SpecializationClassesSet(
 				SpecializationClasses.BERSERKER), LEVEL_REQUIRED_FOR_FIRST_SPECIALIZATION);
-		characterSheet.setData(Fields.BACKGROUND, Background.APOSTATE);
+		characterSheet.setData(Fields.BACKGROUND, Background.HUMAN_APOSTATE);
 	}
 
 	@Test

--- a/RPGManager_development/test/unit_test/character_sheet_unit_tests/SpecializationClassUnitTests.java
+++ b/RPGManager_development/test/unit_test/character_sheet_unit_tests/SpecializationClassUnitTests.java
@@ -1,10 +1,16 @@
 package unit_test.character_sheet_unit_tests;
 
 import static org.junit.Assert.assertEquals;
-import static unit_test.character_sheet_unit_tests.common.CommonMethods.*;
+import static unit_test.character_sheet_unit_tests.common.CommonMethods.LEVEL_REQUIRED_FOR_FIRST_SPECIALIZATION;
+import static unit_test.character_sheet_unit_tests.common.CommonMethods.LEVEL_REQUIRED_FOR_SECOND_SPECIALIZATION;
+import static unit_test.character_sheet_unit_tests.common.CommonMethods.LEVEL_REQUIRED_FOR_THIRD_SPECIALIZATION;
+import static unit_test.character_sheet_unit_tests.common.CommonMethods.createCharacterSheetWithCustomClassesAndLevel;
 
 import java.security.InvalidParameterException;
 
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -33,7 +39,6 @@ public class SpecializationClassUnitTests {
 	private final String MESSAGE_CAN_NOT_TAKE_1_SPECIALIZATION = "Character can't take 1 specialization(s) until level 6!";
 	private final String MESSAGE_CAN_NOT_TAKE_2_SPECIALIZATIONS = "Character can't take 2 specialization(s) until level 14!";
 	private final String MESSAGE_CAN_NOT_TAKE_3_SPECIALIZATIONS = "Character can't take 3 specialization(s) until level 22!";
-	private final String MESSAGE_WARRIOR_NOT_BASECLASS_OF_KEEPER = "Warrior is not a base class of Keeper";
 
 	// test methods
 	@Rule
@@ -85,7 +90,7 @@ public class SpecializationClassUnitTests {
 
 	@Test
 	public void expectException_SetCharacterSpecializationClassFromBerserkerToKeeper_Warrior() {
-		expectExceptionWithMessage(InvalidCharacterClassException.class, MESSAGE_WARRIOR_NOT_BASECLASS_OF_KEEPER);
+		expectExceptionWithMessage(InvalidCharacterClassException.class, "Warrior is not a base class of Keeper");
 		CharacterSheet characterSheet = createCharacterSheetWithCustomClassesAndLevel(BaseClasses.WARRIOR, new SpecializationClassesSet(
 				SpecializationClasses.BERSERKER), LEVEL_REQUIRED_FOR_FIRST_SPECIALIZATION);
 		characterSheet.setData(Fields.SPECIALIZATIONCLASSES, KEEPER);
@@ -93,7 +98,9 @@ public class SpecializationClassUnitTests {
 
 	@Test
 	public void expectException_SetAllFalseCharacterSpecializationClassKeeperAndSpiritHealer_Warrior() {
-		expectExceptionWithMessage(InvalidCharacterClassException.class, MESSAGE_WARRIOR_NOT_BASECLASS_OF_KEEPER);
+		String regexPattern = "\\QWarrior is not a base class of Keeper\\E|\\QWarrior is not a base class of Arcane Warrior\\E";
+		thrown.expect(InvalidCharacterClassException.class);
+		thrown.expectMessage(matchesRegex(regexPattern));
 		CharacterSheet characterSheet = createCharacterSheetWithCustomClassesAndLevel(BaseClasses.WARRIOR, new SpecializationClassesSet(),
 				LEVEL_REQUIRED_FOR_FIRST_SPECIALIZATION);
 		characterSheet.setData(Fields.SPECIALIZATIONCLASSES, KEEPER_ARCANE_WARRIOR);
@@ -210,11 +217,30 @@ public class SpecializationClassUnitTests {
 		thrown.expectMessage(message);
 	}
 
-	public static CharacterSheet createCharacterSheetWithCustomLevelBaseClass(int level, BaseClasses baseClass) {
+	private static CharacterSheet createCharacterSheetWithCustomLevelBaseClass(int level, BaseClasses baseClass) {
 		CharacterSheet characterSheet = new CharacterSheet("CharacterSheet");
 		characterSheet.setData(Fields.BASECLASS, baseClass);
 		characterSheet.setData(Fields.LEVEL, level);
 		return characterSheet;
+	}
+
+	private Matcher<String> matchesRegex(final String regex) {
+		return new TypeSafeMatcher<String>() {
+			@Override
+			protected boolean matchesSafely(final String item) {
+				return item.matches(regex);
+			}
+
+			@Override
+			public void describeTo(Description description) {
+				description.appendText("matches pattern ").appendValue(regex);
+			}
+
+			@Override
+			protected void describeMismatchSafely(String item, Description mismatchDescription) {
+				mismatchDescription.appendText("does not match");
+			}
+		};
 	}
 
 }

--- a/RPGManager_development/test/unit_test/character_sheet_unit_tests/resources/BackgroundUnitTestData.java
+++ b/RPGManager_development/test/unit_test/character_sheet_unit_tests/resources/BackgroundUnitTestData.java
@@ -3,8 +3,8 @@ package unit_test.character_sheet_unit_tests.resources;
 import rpg_database.character_sheet.Background;
 
 final public class BackgroundUnitTestData {
-	final static public Background[] mageOnlyBackgrounds = { Background.APOSTATE, Background.CIRCLE_MAGE, Background.TEVINTER_ALTUS,
-			Background.TEVINTER_LAETAN };
+	final static public Background[] mageOnlyBackgrounds = { Background.CIRCLE_MAGE, Background.ELF_APOSTATE, Background.HUMAN_APOSTATE,
+			Background.TEVINTER_ALTUS, Background.TEVINTER_LAETAN };
 	final static public Background[] rogueOnlyBackgrounds = { Background.DWARF_DUSTER };
 	final static public Background[] rogueAndWarriorBackgrounds = { Background.ANTIVAN_WAYFARER, Background.CITY_ELF, Background.FERELDAN_CRAFTSMEN,
 			Background.FERELDAN_FREEMAN, Background.FERELDAN_NOBLE, Background.FREE_MARCHER, Background.HIGH_BORN_DWARF, Background.LOW_BORN_DWARF,


### PR DESCRIPTION
@Pluci Két gyors bugfixet tolok előkészületből a #18 -ra. Ezeket most vettem észre. írj ha van kérdésed

- Split APOSTATE background into HUMAN_APOSTATE and ELF_APOSTATE,
modified tests accordingly
- Fixed unstable testcase:
expectException_SetAllFalseCharacterSpecializationClassKeeperAndSpiritHealer_Warrior,
since test should have been expecting two types of exception messages instead of
one. Based on how the SpecializationClassesSet was hashed it could have
started failing if the exception message would have warned about the other background.